### PR TITLE
enable "start_stats_thread" in lua interface "start_server"

### DIFF
--- a/h2load_lua.cc
+++ b/h2load_lua.cc
@@ -991,6 +991,7 @@ H2Server_Config_Schema config_schema;
 int start_server(lua_State* L)
 {
     std::string config_file_name;
+    bool b_start_stats = false;
     int top = lua_gettop(L);
     for (int i = 0; i < top; i++)
     {
@@ -1001,6 +1002,11 @@ int start_server(lua_State* L)
                 size_t len;
                 const char* str = lua_tolstring(L, -1, &len);
                 config_file_name.assign(str, len);
+                break;
+            }
+            case LUA_TBOOLEAN:
+            {
+                b_start_stats = lua_toboolean(L, -1);
                 break;
             }
             default:
@@ -1022,13 +1028,13 @@ int start_server(lua_State* L)
 
     std::promise<void> ready_promise;
 
-    auto thread_func = [config_file_name, &ready_promise]()
+    auto thread_func = [config_file_name, &ready_promise, b_start_stats]()
     {
         auto init_cbk = [&ready_promise]()
         {
             ready_promise.set_value();
         };
-        start_server(config_file_name, false, init_cbk);
+        start_server(config_file_name, b_start_stats, init_cbk);
     };
     std::thread serverThread(thread_func);
     auto bootstrap_thread_id = serverThread.get_id();


### PR DESCRIPTION
 1. enable "start_stats_thread" in lua interface "start_server"
   both
     start_server("maock-cnsbc-plus.json", true)
   and
     start_server("maock-cnsbc-plus.json")
   would work.

2. re-format statistic output
  - make stats headers align with values
  - make stats header appear always instead of 1/10

         req-name,      resp-name,       msg-total, throttled-total,      rps,   throttled-rps
GetPCFBindings-v4, PCFBindings-v4,               0,               0,        0,               0
GetPCFBindings-v6, PCFBindings-v6,               0,               0,        0,               0
  PostAppSessions,     CREATE_ASC,            6002,               0,        0,               0
    ModAppSession,     UPDATE_ASC,            6000,               0,        0,               0
 DeleteAppSession,     DELETE_ASC,               0,               0,        0,               0
       NOTIFY-FRA,            204,            1202,               0,       20,               0
           [hook],            ---,               0,               0,        0,               0
      Notify Back,     RESP_W_204,            1202,               0,       20,               0
              SUM,            SUM,           14406,               0,       40,               0
        UNMATCHED,            ---,               0,             ---,        0,             ---